### PR TITLE
Updated chalk to version 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "assetgraph": "*",
     "mime": "*",
     "async": "1.4.2",
-    "chalk": "~0.4.0"
+    "chalk": "1.1.1"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.7.0",


### PR DESCRIPTION
:rocket:

chalk just published version 1.1.1, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/chalk/chalk/releases/tag/v1.1.1)

Fixes a very strange issue with using the same name for a variable and it's assigned function. https://github.com/chalk/chalk/issues/81

Probably a V8 bug.

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
